### PR TITLE
Converted the `rateSetId` to a configurable value based on the incoming `rateDetails`

### DIFF
--- a/src/admin/api.js
+++ b/src/admin/api.js
@@ -389,10 +389,6 @@ function buildDecimalRate(rate, decimalPlaces) {
 function getForexProviderInfo(forexProviderName, currencyPair, rateDetails) {
     switch (forexProviderName) {
         case FOREX_PROVIDERS.CITI: {
-            const RATE_ID_PER_CURRENCY_PAIR = {
-                EURMAD: '43',
-            };
-
             const TENOR_VALUES = {
                 ON: 'ON', // Same-day settlement.
                 TN: 'TN', //  T+1 settlement, where T = date of order execution.
@@ -431,7 +427,7 @@ function getForexProviderInfo(forexProviderName, currencyPair, rateDetails) {
              */
             return {
                 citi: {
-                    rateSetId: RATE_ID_PER_CURRENCY_PAIR[currencyPair.toUpperCase()],
+                    rateSetId: rateDetails.rateSetId,
                     currencyPair: currencyPair.toUpperCase(),
                     baseCurrency: extractSourceCurrency(currencyPair).toUpperCase(),
                     ratePrecision: rateDetails.decimalRate.toString(),

--- a/test/admin/api.js
+++ b/test/admin/api.js
@@ -495,6 +495,7 @@ describe('API:', () => {
                     rateDetails: {
                         rate: 666667,
                         decimalRate: 4,
+                        rateSetId: '43',
                         startTime: '2019-09-03T12:00:00.000Z',
                         endTime: '2019-09-04T12:00:00.000Z',
                         reuse: true,


### PR DESCRIPTION
It is more useful if that value isn't hardcoded but defined by the caller instead.